### PR TITLE
Potential fix for code scanning alert no. 293: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,6 +132,8 @@ jobs:
   link-check:
     name: Link checker (Lychee)
     needs: build-test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/salvesgustavo22-ops/gsprova-landing-hub/security/code-scanning/293](https://github.com/salvesgustavo22-ops/gsprova-landing-hub/security/code-scanning/293)

To fix the problem, add an explicit permissions block to the `link-check` job within `.github/workflows/main.yml` to limit the GITHUB_TOKEN scope to the minimum required. According to the recommendation, the best starting point is `contents: read`, which allows jobs to read repository contents but not alter them. This should be placed directly under the `link-check:` job definition (e.g., after `needs:` or `name:` but before `runs-on:`), and before any steps. No imports or other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
